### PR TITLE
Added option to toggle As-you-type completion

### DIFF
--- a/doc/vim-simple-complete.txt
+++ b/doc/vim-simple-complete.txt
@@ -29,6 +29,9 @@ Press Tab to trigger completion. When the completion popup is visible, use Tab/S
 " Enable/Disable tab key completion mapping
 let g:vsc_tab_complete = 1
 
+" Enable/Disable As-you-type completion
+let g:vsc_type_complete = 1
+
 " Completion command used
 let g:vsc_completion_command = "\<C-P>"
 

--- a/plugin/vim-simple-complete.vim
+++ b/plugin/vim-simple-complete.vim
@@ -4,6 +4,7 @@ endif
 let g:loaded_vim_simple_complete = 1
 
 let g:vsc_tab_complete = get(g:, 'vsc_tab_complete', 1)
+let g:vsc_type_complete = get(g:, 'vsc_type_complete', 1)
 let g:vsc_completion_command = get(g:, 'vsc_completion_command', "\<C-P>")
 let g:vsc_reverse_completion_command = get(g:, 'vsc_reverse_completion_command', "\<C-N>")
 
@@ -35,7 +36,7 @@ fun! s:TypeCompletePlugin()
     autocmd InsertCharPre * call s:TypeComplete()
 
     fun! s:TypeComplete()
-        if v:char =~ '\K'
+        if g:vsc_type_complete && v:char =~ '\K'
             \ && getline('.')[col('.') - 4] !~ '\K'
             \ && getline('.')[col('.') - 3] =~ '\K'
             \ && getline('.')[col('.') - 2] =~ '\K'


### PR DESCRIPTION
Nice plugin, I really like it!

Sometimes I want to disable the automatic As-you-type completion and just use the tab completion. Therefore I enhanced the code a little bit and use this mapping in my vimrc to quickly toggle As-yout-type completion.
```vim
nnoremap <expr> cos g:vsc_type_complete ? ':let g:vsc_type_complete = 0<CR>' : ':let g:vsc_type_complete = 1<CR>'
```

I thought I would just share this with you. Maybe you like it too and want to include it in your plugin.